### PR TITLE
use abstract method 'next_node_for' in ListBase module and classes

### DIFF
--- a/data_structures/linked_list.rb
+++ b/data_structures/linked_list.rb
@@ -13,6 +13,10 @@ class LinkedList
     @head
   end
 
+  def next_node_for(node)
+    node.next
+  end
+
   def insert(value, index=Float::INFINITY)
     el = Node.normalize(value)
     unless el.nil?

--- a/data_structures/list_base.rb
+++ b/data_structures/list_base.rb
@@ -8,6 +8,10 @@ module ListBase
     raise NotImplementedError, "You must implement method 'starting_node' in #{self.class.name} class"
   end
 
+  def next_node_for(node)
+    raise NotImplementedError, "You must implement method 'next_node_for(node)' in #{self.class.name} class"
+  end
+
   def to_s(separator=', ')
     buffer = []
     each_node do |node|
@@ -31,7 +35,7 @@ module ListBase
       current = starting_node
       until current.nil?
         yield current
-        current = current.next
+        current = next_node_for(current)
       end
     else
       raise "Method each_node needs a block"

--- a/data_structures/stack.rb
+++ b/data_structures/stack.rb
@@ -13,10 +13,14 @@ class Stack
     @head
   end
 
+  def next_node_for(node)
+    node.prev
+  end
+
   def push(value)
     node = Node.normalize(value)
     unless node.nil?
-      node.next = @head unless empty?
+      node.prev = @head unless empty?
       @head = node
     end
     self
@@ -24,7 +28,7 @@ class Stack
 
   def pop
     node = @head
-    @head = @head.next.nil? ? nil : node.next
+    @head = @head.prev.nil? ? nil : node.prev
     node
   end
 


### PR DESCRIPTION
I like link named 'prev' instead of 'next' for Stack
